### PR TITLE
Add envish::group_by

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # envish: Search for environment variables in Rust
 
+`envish` is a Rust library for discovering, iterating and grouping environment variables.
+
 ## Installation
 
 ```bash
@@ -8,7 +10,59 @@ cargo add envish
 
 ## Examples
 
-### Find environment variables with a pattern
+### Grouping environment variables
+
+`envish::group_by` gets a grouped collection of related environment variables.
+
+The group expression must contain two named groups:
+
+- `<group>` describes the substring that groups variables together.
+- `<key>` describes the variable's key in the result.
+
+```rust
+std::env::set_var("FOO_ALLY_AGE", "39");
+std::env::set_var("FOO_ALLY_JOB", "assassin");
+std::env::set_var("FOO_CHARLIE_AGE", "42");
+std::env::set_var("FOO_CHARLIE_JOB", "jester");
+
+let group_expr = r"FOO_(?<group>.+)_(?<key>.+)";
+let mut groups = envish::group_by(group_expr).unwrap();
+
+let ally = &groups["ALLY"];
+assert_eq!(ally["AGE"], "39");
+assert_eq!(ally["JOB"], "assassin");
+
+let charlie = &groups["CHARLIE"];
+assert_eq!(charlie["AGE"], "42");
+assert_eq!(charlie["JOB"], "jester");
+```
+
+### Search environment variables by regular expression
+
+`envish::search()` returns an iterator over all environment variables with names that match a given expression.
+
+```rust
+std::env::set_var("CAT_CLOWNS_WOO", "woo");
+std::env::set_var("IMP_JESTER_FOO", "foo");
+std::env::set_var("DOG_JUGGLE_WAR", "war");
+std::env::set_var("IMP_JESTER_BAR", "bar");
+
+let expr = "(.*)_JESTER_(.*)";
+let mut matches = envish::search(expr).unwrap();
+
+let m = matches.next().unwrap();
+assert_eq!(m.0, "IMP_JESTER_FOO");
+assert_eq!(m.1, "foo");
+
+let m = matches.next().unwrap();
+assert_eq!(m.0, "IMP_JESTER_BAR");
+assert_eq!(m.1, "bar");
+
+let m = matches.next();
+assert!(m.is_none());
+```
+
+### Search environment variables by prefix
 
 `envish::with_prefix()` returns an iterator over all environment variables with the given prefix.
 
@@ -18,49 +72,28 @@ std::env::set_var("IMP_JESTER_FOO", "foo");
 std::env::set_var("DOG_JUGGLE_WAR", "war");
 std::env::set_var("IMP_JESTER_BAR", "bar");
 
-let mut matches = envish::by_pattern("(.*)_JESTER_(.*)").unwrap();
+let prefix = "IMP_JESTER_";
+let mut matches = envish::with_prefix(prefix).unwrap();
 
 let m = matches.next().unwrap();
-
 assert_eq!(m.0, "IMP_JESTER_FOO");
 assert_eq!(m.1, "foo");
 
 let m = matches.next().unwrap();
-
 assert_eq!(m.0, "IMP_JESTER_BAR");
 assert_eq!(m.1, "bar");
 
 let m = matches.next();
-
 assert!(m.is_none());
 ```
 
-### Find environment variables with a prefix
+## Support
 
-`envish::with_prefix()` returns an iterator over all environment variables with the given prefix.
+Please submit all your questions, feature requests and bug reports at [github.com/cariad/envish/issues](https://github.com/cariad/envish/issues). Thank you!
 
-```rust
-std::env::set_var("CAT_CLOWNS_WOO", "woo");
-std::env::set_var("IMP_JESTER_FOO", "foo");
-std::env::set_var("DOG_JUGGLE_WAR", "war");
-std::env::set_var("IMP_JESTER_BAR", "bar");
+## License
 
-let mut matches = envish::with_prefix("IMP_JESTER_").unwrap();
-
-let m = matches.next().unwrap();
-
-assert_eq!(m.0, "IMP_JESTER_FOO");
-assert_eq!(m.1, "foo");
-
-let m = matches.next().unwrap();
-
-assert_eq!(m.0, "IMP_JESTER_BAR");
-assert_eq!(m.1, "bar");
-
-let m = matches.next();
-
-assert!(m.is_none());
-```
+The library is [open-source](https://github.com/cariad/envish) and published under the [MIT License](https://github.com/cariad/envish/blob/main/LICENSE).
 
 ## Author
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,13 @@
 #[doc = include_str!("../README.md")]
 use regex::{Error, Regex};
-use std::ffi::OsString;
+use std::{collections::HashMap, ffi::OsString};
+
+/// The result of an `envish::group_by` operation.
+///
+/// The outer HashMap describes named groups of environment variables.
+///
+/// The inner HashMaps describe each environment variable's key and value.
+type GroupByResult = HashMap<String, HashMap<String, OsString>>;
 
 pub struct Search {
     expr: Regex,
@@ -26,8 +33,61 @@ impl Iterator for Search {
     }
 }
 
-/// Gets an iterator over environment variables with names that match the given
-/// pattern.
+/// Gets a grouped collection of related environment variables.
+///
+/// The group expression must contain two named groups:
+///
+/// - `<group>` describes the substring that groups variables together.
+/// - `<key>` describes the variable's key in the result.
+///
+/// ```rust
+/// std::env::set_var("FOO_ALLY_AGE", "39");
+/// std::env::set_var("FOO_ALLY_JOB", "assassin");
+/// std::env::set_var("FOO_CHARLIE_AGE", "42");
+/// std::env::set_var("FOO_CHARLIE_JOB", "jester");
+///
+/// let group_expr = r"FOO_(?<group>.+)_(?<key>.+)";
+/// let mut groups = envish::group_by(group_expr).unwrap();
+///
+/// let ally = &groups["ALLY"];
+/// assert_eq!(ally["AGE"], "39");
+/// assert_eq!(ally["JOB"], "assassin");
+///
+/// let charlie = &groups["CHARLIE"];
+/// assert_eq!(charlie["AGE"], "42");
+/// assert_eq!(charlie["JOB"], "jester");
+/// ```
+pub fn group_by(expr: &str) -> Result<GroupByResult, Error> {
+    match Regex::new(expr) {
+        Ok(re) => {
+            let mut groups = HashMap::new();
+
+            for p in std::env::vars_os() {
+                match re.captures(p.0.to_str().unwrap()) {
+                    Some(captures) => {
+                        let group_id = &captures["group"];
+
+                        if !groups.contains_key(group_id) {
+                            groups.insert(group_id.to_owned(), HashMap::new());
+                        }
+
+                        groups
+                            .get_mut(group_id)
+                            .unwrap()
+                            .insert(captures["key"].to_string(), p.1);
+                    }
+                    None => continue,
+                }
+            }
+
+            Ok(groups)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Gets an iterator over environment variables with names that match a regular
+/// expression.
 ///
 /// ```rust
 /// std::env::set_var("CAT_CLOWNS_WOO", "woo");
@@ -35,30 +95,28 @@ impl Iterator for Search {
 /// std::env::set_var("DOG_JUGGLE_WAR", "war");
 /// std::env::set_var("IMP_JESTER_BAR", "bar");
 ///
-/// let mut matches = envish::by_pattern("(.*)_JESTER_(.*)").unwrap();
+/// let expr = "(.*)_JESTER_(.*)";
+/// let mut matches = envish::search(expr).unwrap();
 ///
 /// let m = matches.next().unwrap();
-///
 /// assert_eq!(m.0, "IMP_JESTER_FOO");
 /// assert_eq!(m.1, "foo");
 ///
 /// let m = matches.next().unwrap();
-///
 /// assert_eq!(m.0, "IMP_JESTER_BAR");
 /// assert_eq!(m.1, "bar");
 ///
 /// let m = matches.next();
-///
 /// assert!(m.is_none());
 /// ```
-pub fn by_pattern(pattern: &str) -> Result<Search, Error> {
+pub fn search(expr: &str) -> Result<Search, Error> {
     Ok(Search {
+        expr: Regex::new(expr)?,
         vars: std::env::vars_os(),
-        expr: Regex::new(pattern)?,
     })
 }
 
-/// Gets an iterator over environment variables with names that have the given
+/// Gets an iterator over environment variables with names that have a given
 /// prefix.
 ///
 /// ```rust
@@ -67,22 +125,20 @@ pub fn by_pattern(pattern: &str) -> Result<Search, Error> {
 /// std::env::set_var("DOG_JUGGLE_WAR", "war");
 /// std::env::set_var("IMP_JESTER_BAR", "bar");
 ///
-/// let mut matches = envish::with_prefix("IMP_JESTER_").unwrap();
+/// let prefix = "IMP_JESTER_";
+/// let mut matches = envish::with_prefix(prefix).unwrap();
 ///
 /// let m = matches.next().unwrap();
-///
 /// assert_eq!(m.0, "IMP_JESTER_FOO");
 /// assert_eq!(m.1, "foo");
 ///
 /// let m = matches.next().unwrap();
-///
 /// assert_eq!(m.0, "IMP_JESTER_BAR");
 /// assert_eq!(m.1, "bar");
 ///
 /// let m = matches.next();
-///
 /// assert!(m.is_none());
 /// ```
-pub fn with_prefix(pattern: &str) -> Result<Search, Error> {
-    by_pattern(&format!("{}(.*)", pattern))
+pub fn with_prefix(prefix: &str) -> Result<Search, Error> {
+    search(&format!("{}(.*)", prefix))
 }


### PR DESCRIPTION
`envish::group_by` gets a grouped collection of related environment variables.

The group expression must contain two named groups:

- `<group>` describes the substring that groups variables together.
- `<key>` describes the variable's key in the result.

```rust
std::env::set_var("FOO_ALLY_AGE", "39");
std::env::set_var("FOO_ALLY_JOB", "assassin");
std::env::set_var("FOO_CHARLIE_AGE", "42");
std::env::set_var("FOO_CHARLIE_JOB", "jester");

let group_expr = r"FOO_(?<group>.+)_(?<key>.+)";
let mut groups = envish::group_by(group_expr).unwrap();

let ally = &groups["ALLY"];
assert_eq!(ally["AGE"], "39");
assert_eq!(ally["JOB"], "assassin");

let charlie = &groups["CHARLIE"];
assert_eq!(charlie["AGE"], "42");
assert_eq!(charlie["JOB"], "jester");
```